### PR TITLE
Update echo command to use single quotes

### DIFF
--- a/docs/resources/git/ch2-git-fundamental-subcommands.md
+++ b/docs/resources/git/ch2-git-fundamental-subcommands.md
@@ -148,7 +148,7 @@ This shows the `.git` directory alongside the regular and parent directory entri
 Let’s start by adding a README file:
 
 ```bash
-echo "# Welcome to COMP423!" > README.md
+echo '# Welcome to COMP423!\n' > README.md
 ```
 
 This command creates a file named `README.md` with the text \`# Welcome to COMP423!\` as its content. The `>` operator redirects the text into the file. You learned about output redirection in COMP211: Systems Fundamentals.


### PR DESCRIPTION
When I run the command 
`echo "# Welcome to COMP423!" > README.md `
the shell interprets everything after the first quotation as a comment, so it doesn't actually put "# Welcome to COMP423!" into the new README.md file as expected, and instead expects the user to provide an additional quotation mark to close the string. 

Switching to the single quotes resolves this issue for me,